### PR TITLE
Adding Docker Generation Files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+#Avoid large conext send to Docker Deamon
+*
+!front-end/quickstart/target/api-design-studio-*-quickstart.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM centos:7
+LABEL authors="Daniel Cesario <dcesario@redhat.com>"
+ARG RELEASE_VERSION
+
+RUN yum install -y \
+    java-1.8.0-openjdk-headless \
+    unzip \
+  && yum clean all
+
+WORKDIR /opt/apiman-studio
+
+COPY ./front-end/quickstart/target/api-design-studio-${RELEASE_VERSION}-quickstart.zip /opt/apiman-studio
+
+RUN groupadd -r apiman -g 1001 \
+    && useradd -u 1001 -r -g apiman -d /opt/apiman-studio/ -s /sbin/nologin -c "Docker image user" apiman \
+    && chown -R apiman:apiman /opt/apiman-studio/
+
+USER 1001
+RUN unzip  /opt/apiman-studio/api-design-studio-${RELEASE_VERSION}-quickstart.zip \
+    && rm /opt/apiman-studio/api-design-studio-${RELEASE_VERSION}-quickstart.zip
+
+EXPOSE 8080
+
+ENTRYPOINT ["/opt/apiman-studio/apache-tomcat-8.5.12/bin/catalina.sh"]
+CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,51 @@
+.PHONY: all build test run bash tag push pull help kill clean
+.DEFAULT_GOAL := help
+
+NAME = apiman-studio
+NAMESPACE = maneta
+RELEASE_VERSION ?= 0.0.5
+LOCAL_IMAGE := $(NAME):$(RELEASE_VERSION)
+REMOTE_IMAGE := $(NAMESPACE)/$(LOCAL_IMAGE)
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+THISDIR_PATH := $(patsubst %/,%,$(abspath $(dir $(MKFILE_PATH))))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+
+all: build
+
+update: build push
+
+build: ## Build docker image with name LOCAL_IMAGE (NAME:RELEASE_VERSION).
+	docker build -f $(THISDIR_PATH)/Dockerfile -t $(LOCAL_IMAGE) $(PROJECT_PATH) \
+		--build-arg RELEASE_VERSION=$(RELEASE_VERSION)
+
+test: ## Test built LOCAL_IMAGE (NAME:RELEASE_VERSION).
+	docker run --rm -u 10000001 --name $(RELEASE_VERSION) -t -p 8080:8080 -d $(LOCAL_IMAGE)
+	@sleep 1
+	curl localhost:8080
+	docker kill $(RELEASE_VERSION)
+
+run: ## Run the docker in the local machine.
+	docker run --rm -u 1001 --name $(RELEASE_VERSION) -t -p 8080:8080 $(LOCAL_IMAGE)
+
+kill: ## Kill the docker in the local machine.
+	docker kill $(RELEASE_VERSION)
+
+bash: ## Start bash in the build IMAGE_NAME.
+	docker run --rm --entrypoint=/bin/bash -it $(LOCAL_IMAGE)
+
+tag: ## Tag IMAGE_NAME in the docker registry
+	docker tag $(LOCAL_IMAGE) $(REMOTE_IMAGE)
+
+push: tag ## Push to the docker registry
+	docker push $(REMOTE_IMAGE)
+
+pull: ## Pull the docker from the Registry
+	docker pull $(REMOTE_IMAGE)
+
+clean: ## Remove all running docker containers and images
+	docker rmi $(LOCAL_IMAGE) --force
+
+# Check http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+help: ## Print this help
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)


### PR DESCRIPTION
This Adds a Dockerfile for container image generation and a Makefile to operate the image. ```make help``` provides help for the Makefile targets.

Please feel free to change the docker registry namespace. I was using my personal namespace (maneta) for  to test the deployment. 

The requirements to run this are:

* GNU Make
* Docker 